### PR TITLE
feat: [Kraken] Add scenario create-post-for-paid-members-only

### DIFF
--- a/features/01-create-post-for-members-only.feature
+++ b/features/01-create-post-for-members-only.feature
@@ -8,7 +8,7 @@ Feature: Create a post and update the access to Members Only
     And I wait for 2 seconds
     And I navigate to the created post
     When I wait for 2 seconds
-    And I update the created post access to "Members Only"
+    And I update the created post access to "Members only"
     And I navigate to the created post
     And I wait for 2 seconds
     Then I should see the post title "$$name_1" and a banner with text "This post is for subscribers only"

--- a/features/02-create-post-for-paid-members.feature
+++ b/features/02-create-post-for-paid-members.feature
@@ -1,0 +1,15 @@
+Feature: Create a post and update the access to Paid-members Only
+
+  @user1 @web
+  Scenario: Login in the application
+    Given I Login with "<EMAIL>" and "<PASSWORD>"
+    And I wait for 2 seconds
+    And I create a new post with title "$name_1" and content "$name_2"
+    And I wait for 2 seconds
+    And I navigate to the created post
+    When I wait for 2 seconds
+    And I update the created post access to "Paid-members only"
+    And I navigate to the created post
+    And I wait for 2 seconds
+    Then I should see the post title "$$name_1" and a banner with text "This post is for paying subscribers only"
+

--- a/src/web/page-objects/post-page.ts
+++ b/src/web/page-objects/post-page.ts
@@ -7,8 +7,8 @@ export class PostPage {
   createPostUrl: string;
   private accessTypeMap = new Map([
     ["Public", "public"],
-    ["Members Only", "members"],
-    ["Paid-Members only", "paid"],
+    ["Members only", "members"],
+    ["Paid-members only", "paid"],
     ["Specific tier(s)", "tiers"],
   ]);
   publishedPostUrl: string;
@@ -93,10 +93,9 @@ export class PostPage {
       "[data-test-select='post-visibility']"
     );
     await postVisibilitySelect.waitForDisplayed({ timeout: 5000 });
-    await postVisibilitySelect.selectByAttribute(
-      "value",
-      this.accessTypeMap.get(accessType)
-    );
+    const accessTypeValue = this.accessTypeMap.get(accessType);
+    if (!accessTypeValue) throw new Error("Invalid access type");
+    await postVisibilitySelect.selectByAttribute("value", accessTypeValue);
     await this.pause();
   }
 


### PR DESCRIPTION
```gherkin
Feature: Create a post and update the access to Paid-members Only

  @user1 @web
  Scenario: Login in the application
    Given I Login with "<EMAIL>" and "<PASSWORD>"
    And I wait for 2 seconds
    And I create a new post with title "$name_1" and content "$name_2"
    And I wait for 2 seconds
    And I navigate to the created post
    When I wait for 2 seconds
    And I update the created post access to "Paid-members only"
    And I navigate to the created post
    And I wait for 2 seconds
    Then I should see the post title "$$name_1" and a banner with text "This post is for paying subscribers only"
```