### PR TITLE
feat: [Kraken] Add scenario create-post-and-unpublish-it

### DIFF
--- a/ghost-e2e-kraken/features/05-create-post-and-unpublish-it.feature
+++ b/ghost-e2e-kraken/features/05-create-post-and-unpublish-it.feature
@@ -1,0 +1,15 @@
+Feature: Create and update Posts
+
+  @user1 @web
+  Scenario: Create a post and unpublish it should not allow to see it
+    Given I Login with "<EMAIL>" and "<PASSWORD>"
+    And I wait for 2 seconds
+    And I create a new post with title "$name_1" and content "$name_2"
+    And I wait for 2 seconds
+    And I navigate to the created post
+    And I should see the post title "$$name_1" and content "$$name_2"
+    When I unpublish the created post
+    And I wait for 2 seconds
+    And I navigate to the created post
+    And I wait for 2 seconds
+    Then I should see a "Page not found" error and an error code 404

--- a/ghost-e2e-kraken/src/web/page-objects/post-page.ts
+++ b/ghost-e2e-kraken/src/web/page-objects/post-page.ts
@@ -95,6 +95,24 @@ export class PostPage {
     await this.pause();
   }
 
+  async clickUnpublishButton() {
+    const unpublishButton = await this.driver.$(
+      ".gh-unpublish-trigger[data-test-button='update-flow']"
+    );
+    await unpublishButton.waitForDisplayed({ timeout: 5000 });
+    await unpublishButton.click();
+    await this.pause();
+  }
+
+  async clickUnpublishAndRevertToDraft() {
+    const revertToDraftButton = await this.driver.$(
+      "[data-test-button='revert-to-draft']"
+    );
+    await revertToDraftButton.waitForDisplayed({ timeout: 5000 });
+    await revertToDraftButton.click();
+    await this.pause();
+  }
+
   // some changes to the settings are triggered by moving away from the modified element
   async saveSettingsChange() {
     await this.clickSettingsButton();

--- a/ghost-e2e-kraken/src/web/step_definitions/posts.step.ts
+++ b/ghost-e2e-kraken/src/web/step_definitions/posts.step.ts
@@ -55,6 +55,12 @@ When(
   }
 );
 
+When("I unpublish the created post", async function (this: KrakenWorld) {
+  await this.postPage.navigateToEditPost();
+  await this.postPage.clickUnpublishButton();
+  await this.postPage.clickUnpublishAndRevertToDraft();
+});
+
 Then(
   "I should see the post title {kraken-string} and content {kraken-string}",
   async function (this: KrakenWorld, title: string, content: string) {


### PR DESCRIPTION
```gherkin
Feature: Create and update Posts

  @user1 @web
  Scenario: Create a post and unpublish it should not allow to see it
    Given I Login with "<EMAIL>" and "<PASSWORD>"
    And I wait for 2 seconds
    And I create a new post with title "$name_1" and content "$name_2"
    And I wait for 2 seconds
    And I navigate to the created post
    And I should see the post title "$$name_1" and content "$$name_2"
    When I unpublish the created post
    And I wait for 2 seconds
    And I navigate to the created post
    And I wait for 2 seconds
    Then I should see a "Page not found" error and an error code 404
```