### PR TITLE
feat: [Kraken] Add scenario create-member-and-verify

### DIFF
--- a/ghost-e2e-kraken/features/07-create-member-and-verify.feature
+++ b/ghost-e2e-kraken/features/07-create-member-and-verify.feature
@@ -1,0 +1,14 @@
+Feature: Create and view members
+
+  @user1 @web
+  Scenario: Create a member and display it on the members list
+    Given I Login with "<EMAIL>" and "<PASSWORD>"
+    And I wait for 2 seconds
+    And I navigate to the members list
+    When I create a new member with name "$name1" and email "$email"
+    And I wait for 2 seconds
+    And I navigate to the members list
+    Then I should see the member with name "$$name1" and email "$$email"
+    When I navigate to the created member
+    And I wait for 2 seconds
+    Then I should see the "$$name1" and "$$email" of the created member.

--- a/ghost-e2e-kraken/src/web/page-objects/member-page.ts
+++ b/ghost-e2e-kraken/src/web/page-objects/member-page.ts
@@ -1,0 +1,101 @@
+import { BASE_URL } from "./constants";
+import type { Browser } from "webdriverio";
+
+export class MemberPage {
+  driver: Browser<"async">;
+  url = BASE_URL + "/ghost/#/members";
+  createNewMemberUrl = BASE_URL + "/ghost/#/members/new";
+  createdMemberUrl = "";
+
+  constructor(driver: Browser<"async">) {
+    this.driver = driver;
+  }
+
+  async pause(milliseconds = 1000) {
+    await this.driver.pause(milliseconds);
+  }
+
+  async navigateToMembersList() {
+    await this.driver.url(this.url);
+    await this.pause();
+  }
+
+  async navigateToCreateNewMember() {
+    await this.driver.url(this.createNewMemberUrl);
+    await this.pause();
+  }
+
+  async navigateToCreatedMember() {
+    await this.driver.url(this.createdMemberUrl);
+    await this.pause();
+  }
+
+  async setMemberName(name: string) {
+    const memberNameElement = await this.driver.$("#member-name");
+    await memberNameElement.waitForDisplayed({ timeout: 5000 });
+    await memberNameElement.setValue(name);
+    await this.pause();
+  }
+
+  async setMemberEmail(email: string) {
+    const memberEmailElement = await this.driver.$("#member-email");
+    await memberEmailElement.waitForDisplayed({ timeout: 5000 });
+    await memberEmailElement.setValue(email);
+    await this.pause();
+  }
+
+  async setMemberLabel(label: string) {
+    const memberLabelElement = await this.driver.$("#member-label");
+    await memberLabelElement.waitForDisplayed({ timeout: 5000 });
+    await memberLabelElement.setValue(label);
+    await this.pause();
+  }
+
+  async clickSaveMemberButton() {
+    const saveButton = await this.driver.$("button[data-test-button='save']");
+    await saveButton.waitForDisplayed({ timeout: 5000 });
+    await saveButton.click();
+    await this.pause();
+  }
+
+  async setCreatedMemberUrl() {
+    this.createdMemberUrl = await this.driver.getUrl();
+  }
+
+  async getMembersListData() {
+    const membersList = await this.driver.$$("h3.gh-members-list-name");
+    const membersData = [];
+    for (const member of membersList) {
+      const memberName = await member.getText();
+      const classes = await member.getAttribute("class");
+      const hasNoNameClass = classes.includes("gh-members-name-noname");
+      if (hasNoNameClass) {
+        membersData.push({ name: null, email: memberName });
+        continue;
+      }
+      const memberEmailElement = await member.nextElement();
+      const memberEmail = await memberEmailElement?.getText();
+      membersData.push({ name: memberName, email: memberEmail });
+    }
+    return membersData;
+  }
+
+  async getMemberDetails() {
+    const memberMainInfoElement = await this.driver.$(
+      "div.gh-member-details-identity > div > h3"
+    );
+
+    await memberMainInfoElement.waitForDisplayed({ timeout: 5000 });
+    const memberMainInfoText = await memberMainInfoElement.getText();
+    const memberAdditionalInfoElement = await this.driver.$(
+      "div.gh-member-details-identity > div > p"
+    );
+    const linkElements = await memberAdditionalInfoElement.$$("a");
+    if (linkElements.length > 0) {
+      const email = await linkElements[0].getText();
+      return { name: memberMainInfoText, email };
+    } else {
+      return { name: null, email: memberMainInfoText };
+    }
+  }
+}

--- a/ghost-e2e-kraken/src/web/step_definitions/members.step.ts
+++ b/ghost-e2e-kraken/src/web/step_definitions/members.step.ts
@@ -1,0 +1,45 @@
+import { Given, When, Then } from "@cucumber/cucumber";
+import { KrakenWorld } from "../support/support";
+import assert from "assert";
+
+Given("I navigate to the members list", async function (this: KrakenWorld) {
+  await this.memberPage.navigateToMembersList();
+});
+
+When(
+  "I create a new member with name {kraken-string} and email {kraken-string}",
+  async function (this: KrakenWorld, name: string, email: string) {
+    await this.memberPage.navigateToMembersList();
+    await this.memberPage.navigateToCreateNewMember();
+    await this.memberPage.setMemberName(name);
+    await this.memberPage.setMemberEmail(email);
+    await this.memberPage.clickSaveMemberButton();
+    await this.memberPage.setCreatedMemberUrl();
+  }
+);
+
+Then(
+  "I should see the member with name {kraken-string} and email {kraken-string}",
+  async function (this: KrakenWorld, name: string, email: string) {
+    const membersList = await this.memberPage.getMembersListData();
+    const member = membersList.find(
+      (m) => m.name === name && m.email === email
+    );
+
+    assert(member?.name === name);
+    assert(member?.email === email);
+  }
+);
+
+When("I navigate to the created member", async function (this: KrakenWorld) {
+  await this.memberPage.navigateToCreatedMember();
+});
+
+Then(
+  "I should see the {kraken-string} and {kraken-string} of the created member.",
+  async function (this: KrakenWorld, name: string, email: string) {
+    const memberDetails = await this.memberPage.getMemberDetails();
+    assert(memberDetails?.name === name);
+    assert(memberDetails.email === email);
+  }
+);

--- a/ghost-e2e-kraken/src/web/support/support.ts
+++ b/ghost-e2e-kraken/src/web/support/support.ts
@@ -5,6 +5,7 @@ import {
   IWorldOptions,
 } from "@cucumber/cucumber";
 import { LoginPage } from "../page-objects/login-page";
+import { MemberPage } from "../page-objects/member-page";
 import { PostPage } from "../page-objects/post-page";
 
 export class KrakenWorld extends World {
@@ -15,6 +16,7 @@ export class KrakenWorld extends World {
   driver: any;
   deviceClient: any;
   loginPage!: LoginPage;
+  memberPage!: MemberPage;
   postPage!: PostPage;
   constructor(input: IWorldOptions) {
     super(input);
@@ -27,6 +29,7 @@ export class KrakenWorld extends World {
 
   async init() {
     this.loginPage = new LoginPage(this.driver);
+    this.memberPage = new MemberPage(this.driver);
     this.postPage = new PostPage(this.driver);
   }
 }


### PR DESCRIPTION
```gherkin
Feature: Create and view members

  @user1 @web
  Scenario: Create a member and display it on the members list
    Given I Login with "<EMAIL>" and "<PASSWORD>"
    And I wait for 2 seconds
    And I navigate to the members list
    When I create a new member with name "$name1" and email "$email"
    And I wait for 2 seconds
    And I navigate to the members list
    Then I should see the member with name "$$name1" and email "$$email"
    When I navigate to the created member
    And I wait for 2 seconds
    Then I should see the "$$name1" and "$$email" of the created member.
```