### PR TITLE
feat: [Kraken] Add scenario edit-member-from-impersonate

### DIFF
--- a/ghost-e2e-kraken/features/08-edit-member-from-impersonate.feature
+++ b/ghost-e2e-kraken/features/08-edit-member-from-impersonate.feature
@@ -1,0 +1,14 @@
+Feature: Edit and view members
+
+  @user1 @web
+  Scenario: Edit a member from the Impersonate link
+    Given I Login with "<EMAIL>" and "<PASSWORD>"
+    And I navigate to the members list
+    And I create a new member with name "$name_1" and email "$email"
+    And I get the Impersonate link
+    When I copy link
+    And I navigate to the Impersonate link in another tab
+    And I edit member with name "$name_2" from Impersonate link
+    And I wait for 2 seconds
+    And I return and refresh the members list in the administration panel
+    Then I should see the member with name "$$name_2" and email "$$email"

--- a/ghost-e2e-kraken/src/web/page-objects/member-page.ts
+++ b/ghost-e2e-kraken/src/web/page-objects/member-page.ts
@@ -6,6 +6,7 @@ export class MemberPage {
   url = BASE_URL + "/ghost/#/members";
   createNewMemberUrl = BASE_URL + "/ghost/#/members/new";
   createdMemberUrl = "";
+  impersonateLink = "";
 
   constructor(driver: Browser<"async">) {
     this.driver = driver;
@@ -28,6 +29,11 @@ export class MemberPage {
   async navigateToCreatedMember() {
     await this.driver.url(this.createdMemberUrl);
     await this.pause();
+  }
+
+  async navigateToImpersonateLink() {
+    await this.driver.url(this.impersonateLink);
+    await this.pause(5000);
   }
 
   async setMemberName(name: string) {
@@ -62,6 +68,10 @@ export class MemberPage {
     this.createdMemberUrl = await this.driver.getUrl();
   }
 
+  async setImpersonateLink(link: string) {
+    this.impersonateLink = link;
+  }
+
   async getMembersListData() {
     const membersList = await this.driver.$$("h3.gh-members-list-name");
     const membersData = [];
@@ -78,6 +88,75 @@ export class MemberPage {
       membersData.push({ name: memberName, email: memberEmail });
     }
     return membersData;
+  }
+
+  async clickMemberSettingsButton() {
+    const memberSettingsButton = await this.driver.$(
+      "button[data-test-button='member-actions']"
+    );
+    await memberSettingsButton.waitForDisplayed({ timeout: 5000 });
+    await memberSettingsButton.click();
+    await this.pause();
+  }
+
+  async clickImpersonateButton() {
+    const impersonateButton = await this.driver.$(
+      "button[data-test-button='impersonate']"
+    );
+    await impersonateButton.waitForDisplayed({ timeout: 5000 });
+    await impersonateButton.click();
+    await this.pause();
+  }
+
+  async copyImpersonateLink() {
+    const impersonateCopyLinkElement = await this.driver.$(
+      "input[data-test-input='member-signin-url']"
+    );
+    await impersonateCopyLinkElement.waitForDisplayed({ timeout: 5000 });
+    const link = await impersonateCopyLinkElement.getValue();
+    return link;
+  }
+
+  async clickMemberAccountButton() {
+    const memberAccountButton = await this.driver.$("a[data-portal='account']");
+    await memberAccountButton.waitForDisplayed({ timeout: 15000 });
+    await memberAccountButton.click();
+    await this.pause();
+  }
+
+  async editMemberNameInFrame(name: string) {
+    const popupFrameElement = await this.driver.$(
+      "[data-testid='portal-popup-frame']"
+    );
+    await popupFrameElement.waitForDisplayed({ timeout: 5000 });
+    await this.driver.switchToFrame(popupFrameElement);
+    const editMemberButton = await this.driver.$(
+      "[data-test-button='edit-profile']"
+    );
+    await editMemberButton.waitForDisplayed({ timeout: 5000 });
+    await editMemberButton.click();
+    await this.setMemberEditNameInFrame(name);
+    await this.clickSaveAccountMemberButtonInFrame();
+    await this.driver.switchToParentFrame();
+    await this.pause();
+  }
+
+  private async setMemberEditNameInFrame(name: string) {
+    const memberEditNameElement = await this.driver.$(
+      "[data-test-input='input-name']"
+    );
+    await memberEditNameElement.waitForDisplayed({ timeout: 5000 });
+    await memberEditNameElement.setValue(name);
+    await this.pause();
+  }
+
+  private async clickSaveAccountMemberButtonInFrame() {
+    const saveMemberButton = await this.driver.$(
+      "button[data-test-button='save-button']"
+    );
+    await saveMemberButton.waitForDisplayed({ timeout: 5000 });
+    await saveMemberButton.click();
+    await this.pause();
   }
 
   async getMemberDetails() {

--- a/ghost-e2e-kraken/src/web/step_definitions/members.step.ts
+++ b/ghost-e2e-kraken/src/web/step_definitions/members.step.ts
@@ -18,6 +18,38 @@ When(
   }
 );
 
+Given("I get the Impersonate link", async function (this: KrakenWorld) {
+  await this.memberPage.clickMemberSettingsButton();
+  await this.memberPage.clickImpersonateButton();
+});
+
+When("I copy link", async function (this: KrakenWorld) {
+  const impersonateLink = await this.memberPage.copyImpersonateLink();
+  this.memberPage.setImpersonateLink(impersonateLink);
+});
+
+When(
+  "I navigate to the Impersonate link in another tab",
+  async function (this: KrakenWorld) {
+    await this.memberPage.navigateToImpersonateLink();
+  }
+);
+
+When(
+  "I edit member with name {kraken-string} from Impersonate link",
+  async function (this: KrakenWorld, name: string) {
+    await this.memberPage.clickMemberAccountButton();
+    await this.memberPage.editMemberNameInFrame(name);
+  }
+);
+
+When(
+  "I return and refresh the members list in the administration panel",
+  async function (this: KrakenWorld) {
+    await this.memberPage.navigateToMembersList();
+  }
+);
+
 Then(
   "I should see the member with name {kraken-string} and email {kraken-string}",
   async function (this: KrakenWorld, name: string, email: string) {


### PR DESCRIPTION
```gherkin
Feature: Edit and view members

  @user1 @web
  Scenario: Edit a member from the Impersonate link
    Given I Login with "<EMAIL>" and "<PASSWORD>"
    And I navigate to the members list
    And I create a new member with name "$name_1" and email "$email"
    And I get the Impersonate link
    When I copy link
    And I navigate to the Impersonate link in another tab
    And I edit member with name "$name_2" from Impersonate link
    And I wait for 2 seconds
    And I return and refresh the members list in the administration panel
    Then I should see the member with name "$$name_2" and email "$$email"
```