### PR TITLE
feat: [Kraken] Add scenario delete-member-disable-impersonate

### DIFF
--- a/ghost-e2e-kraken/features/09-delete-member-disable-impersonate.feature
+++ b/ghost-e2e-kraken/features/09-delete-member-disable-impersonate.feature
@@ -1,0 +1,12 @@
+Feature: Delete member
+  @user1 @web
+  Scenario: Delete a member and verify that their access is restricted afterwards
+    Given I Login with "<EMAIL>" and "<PASSWORD>"
+    And I navigate to the members list
+    And I create a new member with name "$name_1" and email "$email"
+    And I get the Impersonate link
+    And I copy link
+    When I select delete member option
+    And I confirm delete member
+    And I navigate to the Impersonate link in another tab
+    Then I should see a message error which say Could not sign in. Login link expired

--- a/ghost-e2e-kraken/src/web/page-objects/member-page.ts
+++ b/ghost-e2e-kraken/src/web/page-objects/member-page.ts
@@ -99,12 +99,52 @@ export class MemberPage {
     await this.pause();
   }
 
+  async clickDeleteMemberButton() {
+    const impersonateButton = await this.driver.$(
+      "button[data-test-button='delete-member']"
+    );
+    await impersonateButton.waitForDisplayed({ timeout: 5000 });
+    await impersonateButton.click();
+    await this.pause();
+  }
+
+  async clickConfirmDeleteMemberButton() {
+    const confirmDeleteButton = await this.driver.$(
+      "button[data-test-button='confirm']"
+    );
+    await confirmDeleteButton.waitForDisplayed({ timeout: 5000 });
+    await confirmDeleteButton.click();
+    await this.pause();
+  }
+
+  async getImpersonateErrorMessage() {
+    const notificationFrameElement = await this.driver.$(
+      ".gh-portal-notification-iframe"
+    );
+    await notificationFrameElement.waitForDisplayed({ timeout: 5000 });
+    await this.driver.switchToFrame(notificationFrameElement);
+    const errorMessage = await this.driver.$(
+      "div.gh-portal-notification.error > p"
+    );
+    await errorMessage.waitForDisplayed({ timeout: 5000 });
+    const errorMessageText = await errorMessage.getText();
+    await this.driver.switchToParentFrame();
+    return errorMessageText;
+  }
+
   async clickImpersonateButton() {
     const impersonateButton = await this.driver.$(
       "button[data-test-button='impersonate']"
     );
     await impersonateButton.waitForDisplayed({ timeout: 5000 });
     await impersonateButton.click();
+    await this.pause();
+  }
+
+  async clickCloseImpersonateDialogButton() {
+    const closeImpersonateDialogButton = await this.driver.$("a.close");
+    await closeImpersonateDialogButton.waitForDisplayed({ timeout: 5000 });
+    await closeImpersonateDialogButton.click();
     await this.pause();
   }
 

--- a/ghost-e2e-kraken/src/web/step_definitions/members.step.ts
+++ b/ghost-e2e-kraken/src/web/step_definitions/members.step.ts
@@ -26,6 +26,7 @@ Given("I get the Impersonate link", async function (this: KrakenWorld) {
 When("I copy link", async function (this: KrakenWorld) {
   const impersonateLink = await this.memberPage.copyImpersonateLink();
   this.memberPage.setImpersonateLink(impersonateLink);
+  await this.memberPage.clickCloseImpersonateDialogButton();
 });
 
 When(
@@ -47,6 +48,23 @@ When(
   "I return and refresh the members list in the administration panel",
   async function (this: KrakenWorld) {
     await this.memberPage.navigateToMembersList();
+  }
+);
+
+When("I select delete member option", async function (this: KrakenWorld) {
+  await this.memberPage.clickMemberSettingsButton();
+  await this.memberPage.clickDeleteMemberButton();
+});
+
+When("I confirm delete member", async function (this: KrakenWorld) {
+  await this.memberPage.clickConfirmDeleteMemberButton();
+});
+
+Then(
+  "I should see a message error which say Could not sign in. Login link expired",
+  async function (this: KrakenWorld) {
+    const errorMessage = await this.memberPage.getImpersonateErrorMessage();
+    assert.match(errorMessage, /Could not sign in. Login link expired/);
   }
 );
 


### PR DESCRIPTION
```gherkin
Feature: Delete member
  @user1 @web
  Scenario: Delete a member and verify that their access is restricted afterwards
    Given I Login with "<EMAIL>" and "<PASSWORD>"
    And I navigate to the members list
    And I create a new member with name "$name_1" and email "$email"
    And I get the Impersonate link
    And I copy link
    When I select delete member option
    And I confirm delete member
    And I navigate to the Impersonate link in another tab
    Then I should see a message error which say Could not sign in. Login link expired
```